### PR TITLE
Added missing denormalization group

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Product.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Product.xml
@@ -86,6 +86,7 @@
         <attribute name="enabled">
             <group>admin:product:read</group>
             <group>admin:product:all</group>
+            <group>admin:product:create</group>
             <group>admin:product:update</group>
         </attribute>
     </class>


### PR DESCRIPTION
| Q  | A |
| ------------- | ------------- |
| Related tickets | https://github.com/bagrinsergiu/brizy-cloud-sylius-demo-template/issues/2 |
| Tests | N |

### Changelog

* Fixed: Enabled property can now be set on product creation