### PR TITLE
added onHand to shop product endpoints

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariant.xml
@@ -52,6 +52,7 @@
             <group>admin:product_variant:update</group>
             <group>admin:product_variant_inventory:read</group>
             <group>admin:product_variant_inventory:update</group>
+            <group>shop:product_variant:read</group>
         </attribute>
         <attribute name="weight">
             <group>admin:product_variant:read</group>


### PR DESCRIPTION
| Q  | A |
| ------------- | ------------- |
| Related tickets | https://github.com/bagrinsergiu/brizy-cloud-sylius-demo-template/issues/128 |
| Tests | N |

### Changelog

* Improved: Product variants through shop endpoint will return "onHand" property now.
