### PR TITLE
Add `description`  field in `translations` for create product endpoint 

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Product.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Product.xml
@@ -116,6 +116,7 @@
                         <attribute name="name">string</attribute>
                         <attribute name="slug">string</attribute>
                         <attribute name="locale">string</attribute>
+                        <attribute name="description">string</attribute>
                     </attribute>
                 </attribute>
             </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAttributeValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAttributeValue.xml
@@ -41,6 +41,14 @@
                     <attribute name="groups">admin:product_attribute_value:read</attribute>
                 </attribute>
             </itemOperation>
+
+            <itemOperation name="shop_get">
+                <attribute name="method">GET</attribute>
+                <attribute name="path">/shop/product-attribute-values/{id}</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">shop:product_attribute_value:read</attribute>
+                </attribute>
+            </itemOperation>
         </itemOperations>
 
         <property name="id" identifier="true" writable="false" />


### PR DESCRIPTION
| Q  | A |
| ------------- | ------------- |
| Related tickets | _replace example with your answer_ ex: #123 or N/A |
| Tests | _replace example with your answer_ ex: Y / N |

_All table fields are required_


### Changelog

_replace example with your answer_
* New: Added Image LightBox
* Improved: Image resizing will now happen locally in WP instead of on Brizy servers
* Updated: Carousel library that is used in the editor (react-slick)
* Fixed: Text space for ordered and unordered lists
