### PR TITLE
Add product description field

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Product.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Product.xml
@@ -114,8 +114,8 @@
                 <attribute name="example">
                     <attribute name="en_US">
                         <attribute name="name">string</attribute>
-                        <attribute name="slug">string</attribute>
                         <attribute name="locale">string</attribute>
+                        <attribute name="description">string</attribute>
                     </attribute>
                 </attribute>
             </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductTranslation.xml
@@ -24,5 +24,11 @@
             <group>admin:product:update</group>
             <group>shop:product:read</group>
         </attribute>
+        <attribute name="description">
+            <group>admin:product:read</group>
+            <group>admin:product:create</group>
+            <group>admin:product:update</group>
+            <group>shop:product:read</group>
+        </attribute>
     </class>
 </serializer>


### PR DESCRIPTION
### Changelog
product `description` field is placed inside of translations and can be accessed via get(collection and item), post and put operations.
related issue: bagrinsergiu/brizy-cloud-sylius-demo-template/issues/149
