### PR TITLE
fixed admin put payment-method

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PaymentMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PaymentMethod.xml
@@ -37,7 +37,7 @@
 
             <itemOperation name="admin_update">
                 <attribute name="method">PUT</attribute>
-                <attribute name="path">/admin/payment-methods/{id}</attribute>
+                <attribute name="path">/admin/payment-methods/{code}</attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">admin:payment_method:update</attribute>
                 </attribute>


### PR DESCRIPTION
### Changelog
added `code` as item identifier for put payment method;
related issues: 

- bagrinsergiu/brizy-cms-ui#1877
- bagrinsergiu/brizy-cloud-sylius-demo-template/issues/153
