### PR TITLE
Add GatewayConfig(factory_name and gateway_name) fields to admin:payment_method:read group

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/GatewayConfig.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/GatewayConfig.xml
@@ -26,9 +26,11 @@
         </attribute>
         <attribute name="factory_name">
             <group>admin:gateway_config:read</group>
+            <group>admin:payment_method:read</group>
         </attribute>
         <attribute name="gateway_name">
             <group>admin:gateway_config:read</group>
+            <group>admin:payment_method:read</group>
         </attribute>
     </class>
 </serializer>


### PR DESCRIPTION
Add GatewayConfig(factory_name and gateway_name) fields to admin:payment_method:read group
**related issues**:
- bagrinsergiu/brizy-cloud-sylius-demo-template/issues/166
- bagrinsergiu/brizy-cms-ui/issues/1931
