### PR TITLE
Remove redundant group from ProductOptionValue's normalization_context

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOptionValue.xml
@@ -20,7 +20,6 @@
         <attribute name="normalization_context">
             <attribute name="groups">
                 <attribute>admin:product_option_value:read</attribute>
-                <attribute>admin:product_option_value:create</attribute>
             </attribute>
         </attribute>
 


### PR DESCRIPTION
### Changelog
*Remove redundant group from ProductOptionValue's normalization_context*

**related issues:**
- https://github.com/bagrinsergiu/brizy-cms-ui/issues/2066
- https://github.com/bagrinsergiu/brizy-cloud-sylius-demo-template/issues/165
