### PR TITLE
Display a productTaxon object instead of IRI when reading products

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductTaxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductTaxon.xml
@@ -7,13 +7,18 @@
     <class name="Sylius\Component\Core\Model\ProductTaxon">
         <attribute name="id">
             <group>admin:product_taxon:read</group>
+            <group>admin:product:read</group>
             <group>shop:product_taxon:read</group>
         </attribute>
         <attribute name="taxon">
             <group>admin:product_taxon:read</group>
             <group>shop:product_taxon:read</group>
             <group>admin:product:create</group>
+            <group>admin:product:read</group>
             <group>admin:product:update</group>
+        </attribute>
+        <attribute name="position">
+            <group>admin:product:read</group>
         </attribute>
     </class>
 </serializer>


### PR DESCRIPTION
**display a productTaxon object instead of IRI when reading products;**
### Changelog

* add `position` attribute to serialization/ProductTaxon.xml
* add admin:produt:read group to id, taxon and postion fields

related issues: 
- https://github.com/bagrinsergiu/brizy-cloud-sylius-demo-template/issues/164
- https://github.com/bagrinsergiu/brizy-cms-ui/issues/2126
