### PR TITLE
Fixed admin post/put ShippingMethod Rules

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingMethod.xml
@@ -102,20 +102,50 @@
             </subresourceOperation>
         </subresourceOperations>
 
-        <property name="id" identifier="false" writable="false" />
-        <property name="code" identifier="true" required="true" />
-        <property name="createdAt" writable="false" />
-        <property name="updatedAt" writable="false" />
-        <property name="archivedAt" writable="false" />
-        <property name="name" writable="true" />
-        <property name="position" writable="true" />
-        <property name="enabled" writable="true" />
-        <property name="zone" writable="true" />
-        <property name="channels" writable="true" />
-        <property name="category" writable="true" />
-        <property name="calculator" writable="true" />
-        <property name="configuration" writable="true" />
-        <property name="rules" writable="true" />
+        <property name="id" identifier="false" writable="false"/>
+        <property name="code" identifier="true" required="true"/>
+        <property name="createdAt" writable="false"/>
+        <property name="updatedAt" writable="false"/>
+        <property name="archivedAt" writable="false"/>
+        <property name="name" writable="true"/>
+        <property name="position" writable="true"/>
+        <property name="enabled" writable="true"/>
+        <property name="zone" writable="true"/>
+        <property name="channels" writable="true"/>
+        <property name="category" writable="true"/>
+        <property name="calculator" writable="true">
+            <attribute name="openapi_context">
+                <attribute name="type">string</attribute>
+                <attribute name="enum">
+                    <attribute>flat_rate</attribute>
+                    <attribute>per_unit_rate</attribute>
+                </attribute>
+                <attribute name="example">flat_rate</attribute>
+            </attribute>
+        </property>
+        <property name="configuration" writable="true" required="false">
+            <attribute name="openapi_context">
+                <attribute name="type">object</attribute>
+                <attribute name="example">
+                    <attribute name="FASHION_WEB">
+                        <attribute name="amount" type="string"/>
+                    </attribute>
+                </attribute>
+            </attribute>
+        </property>
+        <property name="rules" writable="true" required="false">
+            <attribute name="openapi_context">
+                <attribute name="type">object</attribute>
+                <attribute name="example">
+                    <attribute name="type" type="string">string</attribute>
+                    <attribute name="configuration">
+                        <attribute name="FASHION_WEB">
+                            <attribute name="amount">1000</attribute>
+                        </attribute>
+                    </attribute>
+                </attribute>
+            </attribute>
+        </property>
         <property name="translations" readable="true" writable="true">
             <attribute name="openapi_context">
                 <attribute name="type">object</attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingMethod.xml
@@ -90,6 +90,8 @@
 
         <attribute name="rules">
             <group>admin:shipping_method:read</group>
+            <group>admin:shipping_method:create</group>
+            <group>admin:shipping_method:update</group>
         </attribute>
     </class>
 </serializer>


### PR DESCRIPTION
Fixed `ShippingMethod` when add/edit `rules`

Related Issues: 
- https://github.com/bagrinsergiu/brizy-cloud-sylius-demo-template/issues/174
- https://github.com/bagrinsergiu/brizy-cms-ui/issues/2164